### PR TITLE
Pg/indexes

### DIFF
--- a/src/coffees/entities/coffees.entity.ts
+++ b/src/coffees/entities/coffees.entity.ts
@@ -1,17 +1,20 @@
 import {
   Column,
   Entity,
+  Index,
   JoinTable,
   ManyToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Flavor } from './flavor.entity';
 
+// @Index(['name', 'brand']) composite indexes containing multiple columns
 @Entity() //pass a 'string' to use a specific name for the table
 export class Coffee {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Index()
   @Column()
   name: string;
 


### PR DESCRIPTION
adds index to entity. Indexes are tables that are used to speedup lookup process if it is a common request